### PR TITLE
Fix: reduce exposed ports

### DIFF
--- a/outline/docker-compose.yml
+++ b/outline/docker-compose.yml
@@ -64,8 +64,6 @@ services:
     env_file: ../stack.env
     networks:
       - outline
-    ports:
-      - "5432:5432"
     volumes:
       - /mnt/ssd-1tb/docker/outline/db:/var/lib/postgresql/data
     healthcheck:

--- a/outline/docker-compose.yml
+++ b/outline/docker-compose.yml
@@ -42,8 +42,6 @@ services:
     image: redis
     restart: unless-stopped
     env_file: ../stack.env
-    ports:
-      - "6379:6379"
     networks:
       - outline
     volumes:


### PR DESCRIPTION
the ports of the
* Postgres DB
* Redis Server

didn't need to be exposed on the internal network.