### PR TITLE
Fix: disable directly exposing the port of VS Code

### DIFF
--- a/vs_code_server/docker-compose.yml
+++ b/vs_code_server/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     user: "${PUID}:${PGID}"
     volumes:
       - ${HOME_DIR}:/home/coder
-    ports:
-      - 8080
     networks:
       - auth_internal
       - traefik


### PR DESCRIPTION
😱  I was able to access my VS Code on the local network by going to `http://my-local-nas:1234`, where `1234` was some random port assigned by Docker 🐳. That's disabled now.