### PR TITLE
Fix: Mattermost `stack.env` reference missing

### DIFF
--- a/mattermost/docker-compose.yml
+++ b/mattermost/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DB
-    env_file: stack.env
+    env_file: ../stack.env
     networks:
       - default
     labels:
@@ -65,7 +65,7 @@ services:
 
       # additional settings
       - MM_SERVICESETTINGS_SITEURL
-    env_file: stack.env
+    env_file: ../stack.env
     networks:
       - auth_internal
       - default

--- a/mattermost/docker-compose.yml
+++ b/mattermost/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DB
+    env_file: stack.env
     networks:
       - default
     labels:
@@ -64,6 +65,7 @@ services:
 
       # additional settings
       - MM_SERVICESETTINGS_SITEURL
+    env_file: stack.env
     networks:
       - auth_internal
       - default


### PR DESCRIPTION
Causes problem in Portainer 2.21.0